### PR TITLE
Controls overlay (Top right only, but can be copied)

### DIFF
--- a/containers/pirate-frontend/Dockerfile
+++ b/containers/pirate-frontend/Dockerfile
@@ -1,4 +1,4 @@
-from node:22-alpine
+FROM node:22-alpine
 
 WORKDIR /app/
 

--- a/containers/pirate-frontend/package.json
+++ b/containers/pirate-frontend/package.json
@@ -11,6 +11,8 @@
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-leaflet": "^5.0.0-rc.2",
+    "react-leaflet-custom-control": "1.5.0",
+    "react-bootstrap": "2.10.10",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/containers/pirate-frontend/src/App.js
+++ b/containers/pirate-frontend/src/App.js
@@ -2,7 +2,15 @@ import PirateMap from './components/PirateMap.js';
 
 function App() {
   return (
-    <PirateMap />
+    <>
+      <link
+        rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/css/bootstrap.min.css"
+        integrity="sha384-SgOJa3DmI69IUzQ2PVdRZhwQ+dy64/BUtbMJw1MZ8t5HZApcHrRKUc4W0kG879m7"
+        crossorigin="anonymous"
+      />
+      <PirateMap />
+    </>
   );
 }
 

--- a/containers/pirate-frontend/src/components/PirateMap.js
+++ b/containers/pirate-frontend/src/components/PirateMap.js
@@ -1,18 +1,25 @@
 import 'leaflet/dist/leaflet.css';
 import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import TopRightControls from './controls/TopRightControls.js';
 
 function PirateMap() {
   return (
     <MapContainer style={{position: "absolute", width: "100%", height: "100%"}} center={[34.7190616534629, -86.64664978111168]} zoom={13}>
+      {/* Base layer source. Maybe update later to include additional options? */}
       <TileLayer
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
+
+      {/* A marker at the location of the Senior Design Class (EXAMPLE ONLY - REMOVE LATER) */}
       <Marker position={[34.7190616534629, -86.64664978111168]}>
         <Popup>
           CS499 - Senior Design
         </Popup>
       </Marker>
+
+      {/* Controls that float above the map in the top right */}
+      <TopRightControls/>
     </MapContainer>
   )
 }

--- a/containers/pirate-frontend/src/components/controls/TopRightControls.js
+++ b/containers/pirate-frontend/src/components/controls/TopRightControls.js
@@ -1,0 +1,30 @@
+import Control from 'react-leaflet-custom-control';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+import Card from 'react-bootstrap/Card';
+
+function TopRightControls() {
+  return (
+    <>
+      <Control prepend position='topright'>
+        <Row className='mb-2 text-end'><Col md="auto">
+          <Card bg='primary' className='rounded'>
+            <Card.Body className="p-2" onClick={() => console.log("Clicked control!")}>Control!</Card.Body>
+          </Card>
+        </Col></Row>
+        <Row className='mb-2 text-end'><Col md="auto">
+          <Card bg='secondary' className='rounded'>
+            <Card.Body className="p-2" onClick={() => console.log("Clicked Second!")}>Second!</Card.Body>
+          </Card>
+        </Col></Row>
+        <Row className='mb-2 text-end'><Col md="auto">
+          <Card bg='light' className='rounded'>
+            <Card.Body className="p-2" onClick={() => console.log("Clicked Other!")}>Other!</Card.Body>
+          </Card>
+        </Col></Row>
+      </Control>
+    </>
+  )
+}
+
+export default TopRightControls;


### PR DESCRIPTION
Adds arbitrary-HTML controls that overlay on the Leaflet map. Currently, the example is in the `topright` and the control contains three super simple clickable buttons created using React Bootstrap (a React implementation of the Bootstrap CSS library).

This change will require a full rebuild, as it installs new packages!