### PR TITLE
Zoom Fixes

### DIFF
--- a/containers/pirate-frontend/src/components/render/OceanCurrentArrows.js
+++ b/containers/pirate-frontend/src/components/render/OceanCurrentArrows.js
@@ -5,17 +5,18 @@ import { getOceanCurrentAtLatLng } from '../../data/oceanCurrents.js';
 import { isOcean } from '../../utils/isOcean.js';
 
 // Only render arrows at zoom >= this level
-const CURRENT_ARROW_MIN_ZOOM = 6;
+const CURRENT_ARROW_MIN_ZOOM = 9;
 
 // Grid spacing in degrees at reference zoom; becomes denser as you zoom in
-const BASE_GRID_SPACING = 2.0;
-const MIN_GRID_SPACING = 0.5;
+const BASE_GRID_SPACING = 0.9;
+const MIN_GRID_SPACING = 0.25;
 
 // Arrow visual tuning
 const ARROW_LENGTH = 28;
 const ARROW_HEAD = 7;
 const ARROW_STROKE = 2;
-const ARROW_COLOR = '#4FC3F7';     // light blue
+const DAY_ARROW_COLOR = '#1e40af';
+const NIGHT_ARROW_COLOR = '#4FC3F7';
 const ARROW_OPACITY = 0.7;
 const MIN_MAGNITUDE = 0.05;        // skip arrows with negligible current
 
@@ -24,7 +25,7 @@ const MIN_MAGNITUDE = 0.05;        // skip arrows with negligible current
  * heading is in radians (0 = east, π/2 = north).
  * scale controls arrow size relative to zoom.
  */
-function createCurrentArrowIcon(heading, magnitude, scale) {
+function createCurrentArrowIcon(heading, magnitude, scale, color) {
   const length = Math.round(ARROW_LENGTH * scale);
   const head = Math.round(ARROW_HEAD * scale);
   const stroke = Math.max(1.5, ARROW_STROKE * scale);
@@ -47,11 +48,11 @@ function createCurrentArrowIcon(heading, magnitude, scale) {
   const svg = `
     <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
       <line x1="0" y1="${centerY}" x2="${tipX}" y2="${centerY}"
-            stroke="${ARROW_COLOR}" stroke-width="${stroke}" stroke-linecap="round" opacity="${opacity}" />
+            stroke="${color}" stroke-width="${stroke}" stroke-linecap="round" opacity="${opacity}" />
       <line x1="${headLeftX}" y1="${headTopY}" x2="${tipX}" y2="${centerY}"
-            stroke="${ARROW_COLOR}" stroke-width="${stroke}" stroke-linecap="round" opacity="${opacity}" />
+            stroke="${color}" stroke-width="${stroke}" stroke-linecap="round" opacity="${opacity}" />
       <line x1="${headLeftX}" y1="${headBottomY}" x2="${tipX}" y2="${centerY}"
-            stroke="${ARROW_COLOR}" stroke-width="${stroke}" stroke-linecap="round" opacity="${opacity}" />
+            stroke="${color}" stroke-width="${stroke}" stroke-linecap="round" opacity="${opacity}" />
     </svg>
   `.trim();
 
@@ -117,9 +118,10 @@ function useCurrentArrows(zoom, map, regionBounds) {
       map.getBounds().getEast()]);
 }
 
-export default function OceanCurrentArrows({ regionBounds }) {
+export default function OceanCurrentArrows({ regionBounds, isNight = false }) {
   const map = useMap();
   const [zoom, setZoom] = useState(map.getZoom());
+  const arrowColor = isNight ? NIGHT_ARROW_COLOR : DAY_ARROW_COLOR;
 
   useMapEvents({
     zoomend: () => setZoom(map.getZoom()),
@@ -136,7 +138,7 @@ export default function OceanCurrentArrows({ regionBounds }) {
         <Marker
           key={`current-${lat}-${lon}`}
           position={[lat, lon]}
-          icon={createCurrentArrowIcon(heading, magnitude, scale)}
+          icon={createCurrentArrowIcon(heading, magnitude, scale, arrowColor)}
           interactive={false}
           zIndexOffset={-1000}
         />

--- a/containers/pirate-frontend/src/components/render/RunDisplay.js
+++ b/containers/pirate-frontend/src/components/render/RunDisplay.js
@@ -104,7 +104,7 @@ export default function RunDisplay({ simState, run }) {
       <PointIcons pointList={pointList} />
       <ShipIcons shipList={shipList} regionCenter={region.center} />
       <EncounterIcons events={encounterEvents} regionCenter={region.center} />
-      <OceanCurrentArrows regionBounds={region.bounds} />
+      <OceanCurrentArrows regionBounds={region.bounds} isNight={mapTheme.isNight} />
 
       {/* TEMPORARY: render patrol paths */}
       {Object.values(run.currentState.ships)

--- a/containers/pirate-frontend/src/components/render/ShipIcons.js
+++ b/containers/pirate-frontend/src/components/render/ShipIcons.js
@@ -6,7 +6,7 @@ import L from 'leaflet';
 import ShipIcon from './ShipIcon.js';
 import { cartesianToLatLng } from '../../utils/coords.js';
 
-const ARROW_MIN_ZOOM = 7;
+const ARROW_MIN_ZOOM = 9;
 const ARROW_BASE_ZOOM = 8;
 const ARROW_MIN_SCALE = 0.7;
 const ARROW_MAX_SCALE = 1.35;


### PR DESCRIPTION
The arrows for the ocean currents and heading now appear at the same zoom level(9) that is two higher than the highest default zoom of a region. The arrows also shift between dark blue during the day and light blue at night. Finally, the density of arrows at high zoom was increased because it was hard to find them.